### PR TITLE
Test middleman build on a CI service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: false
+language: ruby
+cache: bundler
+rvm:
+  - 2.3.0
+  - ruby-head
+script: rake
+matrix:
+  fast_finish: true
+  allow_falures:
+    - rvm: ruby-head
+notifications:
+  # FIXME: use appropriate recipient address
+  email:
+    - tj+travis_alpinelab_website@a13.fr

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,29 @@
+LOCALEAPP_CONFIG      = ".localeapp/config.rb".freeze
+LOCALEAPP_CONFIG_DIR  = LOCALEAPP_CONFIG.pathmap("%d").freeze
+CI_SERVICE_ENV_KEY    = "TRAVIS".freeze
+
+
+directory LOCALEAPP_CONFIG_DIR
+
+file LOCALEAPP_CONFIG => LOCALEAPP_CONFIG_DIR do |t|
+  # FIXME: maybe it would be better to improve localeapp setup, or test env
+  # management, rather than creating a dummy config file.
+  #sh "touch #{t.name}" if ENV.key? CI_SERVICE_ENV_KEY
+  next unless ENV.key? CI_SERVICE_ENV_KEY
+  File.open t.name, "w" do |f|
+    f.write <<-eoh
+Localeapp.configure do |config|
+  config.api_key                    = 'DUMMY_KEY_FOR_TESTS'
+  config.translation_data_directory = 'locales'
+end
+    eoh
+  end
+end
+
+
+task default: :test
+
+desc "Test middleman build"
+task test: LOCALEAPP_CONFIG do
+  sh "bundle exec middleman build"
+end


### PR DESCRIPTION
It's just an idea and suggestion for now, I wanted to check if it was
doable to at least test the build on an external CI service.

Later of course we could add a real test suite, but I think having the
build tested is a nice first step.

I used travis CI service here just because it's easy to use and our
license permits it as far as I know. Later we could also setup
automated deployment after test like we do for other projects (ie:
with Codeship).
