### PR TITLE
Improve blog linking

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -20,7 +20,7 @@ en:
       hire-us_html: email us
       page-description: Ruby/Rails web agency in Lyon focusing on agile development, startups, large web applications.
     footer:
-      articles-title: Latest articles
+      articles-title: Latest blog articles
       copyright: <a rel="publisher" href="https://plus.google.com/+AlpineLab" target="_blank">Alpine Lab</a> website is published under <a href="http://creativecommons.org/licenses/by/3.0/fr/" target="_blank">Creative Commons Attribution 3.0 (cc-by-3.0)</a>. <br>All code is licensed under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT</a>.
       title: Contact us
     header:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -20,7 +20,7 @@ fr:
       hire-us_html: "écrivez nous"
       page-description: Agence web Ruby/Rails à Lyon orientée développement agile, startups, applications web complexes et open-source.
     footer:
-      articles-title: Derniers articles
+      articles-title: Derniers articles du blog
       copyright: Le site d'<a rel="publisher" href="https://plus.google.com/+AlpineLab" target="_blank">Alpine Lab</a> est publié sous license <a href="http://creativecommons.org/licenses/by/3.0/fr/" target="_blank">Creative Commons Attribution 3.0 (cc-by-3.0)</a>. <br>Le code est sous licence <a href="http://opensource.org/licenses/MIT" target="_blank">MIT</a>.
       title: Nous contacter
     header:

--- a/source/_header.html.haml
+++ b/source/_header.html.haml
@@ -10,6 +10,10 @@
         - get_menu_labels(%w{what-we-do our-projects team commitments}).each_with_index do |(key, label), index|
           %li.header__navigation-item
             %a.scroll-to{href: "##{key}"}= label
+        %li.header__navigation-item
+          %a{href: "/blog"}
+            -# FIXME: test/check this change
+            Blog
   
     %a.header__write-us{href: "mailto:dahu@alpine-lab.com", title: I18n.t("corporate.footer.title")}
       %i.fa.fa-pencil


### PR DESCRIPTION
At first, I wanted to add a link to the blog from the homepage and/or
layout, because I couldn't find any. I also checked on a search
engine:

https://encrypted.google.com/search?q=blog+site%3Awww.alpine-lab.com
(matching results are only from the blog itself)

After hacking on the website, I remembered and found where we have
one, but I think it would help if it was more visible (both for users
and search engines).

We could add a link in the header, footer, or just improve current
link text, by adding the word "blog" inside. What do you think, should
we improve this? How?
