### PR TITLE
Fix currency symbol usage (space char) in locales

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -71,7 +71,7 @@ en:
         details: We manage <strong>very high trafic websites</strong> using reliable PaaS technologies to <strong>deploy peacefully</strong> and <strong>scale</strong> automatically applications that we have optimized for <strong>performance</strong> and robustness (caching, background jobs).
         title: Enterprises
       pricing:
-        details: 'As we are working the agile way, invoicing is<br>simple and transparent: <strong class="price">€ 400 / day</strong>.'
+        details: 'As we are working the agile way, invoicing is<br>simple and transparent: <strong class="price">€400 / day</strong>.'
         title: Pricing
       quality:
         details: Our code is <strong>versioned</strong> (git), <strong>organised</strong> (gitflow), <strong>tested</strong> (RSpec, Capybara) within <strong>continuous integration</strong> (Travis, Codeship), <strong>continuous audit</strong> (Codeclimate, code reviews) and <strong>continuous deployment</strong> (Heroku) processes.

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -71,7 +71,7 @@ fr:
         details: Nous exploitons des <strong>sites à très fort trafic</strong> grâce à des technologies PaaS fiables pour <strong>déployer sereinement</strong> et <strong>dimensionner</strong> automatiquement des applications dont nous avons optimisé les <strong>performances</strong> (caching, jobs).
         title: Entreprises
       pricing:
-        details: 'Comme nous travaillons de manière agile, la facturation est<br>simple et transparente : c''est <strong class="price">400€ / jour</strong>.'
+        details: 'Comme nous travaillons de manière agile, la facturation est<br>simple et transparente : c''est <strong class="price">400 € / jour</strong>.'
         title: Prix
       quality:
         details: Notre code est <strong>versionné</strong> (git), <strong>organisé</strong> (gitflow), <strong>testé</strong> (RSpec, Capybara) au sein d'un process d'<strong>intégration continue</strong> (Travis, Codeship), d'<strong>audit continu</strong> (Codeclimate, code reviews) et de <strong>déployement continu</strong> (Heroku).


### PR DESCRIPTION
I couldn't find a reliable source to verify official "rules"
(especially for `en` locales), but I'm pretty sure I rarely see a
space after currency symbol when we use it as a prefix, especially by
users of an `en` locales.
