### PR TITLE
Fix vertical alignement on team names

### DIFF
--- a/source/_team.html.haml
+++ b/source/_team.html.haml
@@ -4,7 +4,7 @@
     - data.team.each do |member|
       .col-4.col.col--centered
         %img{src: gravatar_for(member.email), class: "avatar", alt: member.email}
-        %h4= member.name
+        %h4.names= member.name
         %ul.social-networks
           %li
             %a{href: "https://github.com/#{member.github}", target: "_blank"} Github

--- a/source/stylesheets/corporate/sections/_team.sass
+++ b/source/stylesheets/corporate/sections/_team.sass
@@ -11,6 +11,8 @@
   @include max-width(1280px)
     h4
       font-size: 16px
+  .names
+    height: 2.8em
   @include max-width(1030px)
     .row
       max-width: 500px


### PR DESCRIPTION
Because Paul's name is too long and takes 2 lines,
Social networks links were not aligned anymore