### PR TITLE
Update sprocket to >=2.12.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem "redcarpet"
 gem "rouge"
 gem "middleman-rouge"
 
+gem "sprockets", ">= 2.12.5"
+
 gem "bootstrap-sass"
 
 gem "localeapp"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.3.0)
     minitest (5.9.0)
-    multi_json (1.12.1)
+    multi_json (1.13.1)
     netrc (0.11.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
@@ -132,7 +132,7 @@ GEM
       tilt (~> 1.4.1)
     padrino-support (0.12.7)
       activesupport (>= 3.1)
-    rack (1.6.8)
+    rack (1.6.10)
     rack-livereload (0.3.15)
       rack
     rack-test (0.6.3)
@@ -147,7 +147,7 @@ GEM
       netrc (~> 0.8)
     rouge (1.8.0)
     sass (3.4.22)
-    sprockets (2.12.4)
+    sprockets (2.12.5)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)
@@ -190,6 +190,7 @@ DEPENDENCIES
   nokogiri
   redcarpet
   rouge
+  sprockets (>= 2.12.5)
 
 BUNDLED WITH
    1.16.1


### PR DESCRIPTION
High security alert on sprocket [source](https://nvd.nist.gov/vuln/detail/CVE-2018-3760)