### PR TITLE
Add Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: false
+language: ruby
+cache: bundler
+rvm:
+  - 2.5
+script:
+  - bundle exec middleman build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ volumes:
   config: { driver: local }
 services:
   app:
-    image: alpinelab/ruby-dev
+    image: alpinelab/ruby-dev:2.5
     command: ["middleman", "server", "--bind-address=0.0.0.0"]
     ports:
       - "4567:4567"


### PR DESCRIPTION
This commit adds a very basic Travis configuration. It also explicitly
settles down the Ruby version used even in Docker (to 2.5).