### PR TITLE
Remove team members information from locale files

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -79,27 +79,7 @@ en:
       join-us: |-
         You want to join us? We're always looking for passionate developers !<br>
         Add yourself to the team and create <a href="https://github.com/alpinelab/website">a pull request</a> :-)
-      mike:
-        email: michael.baudino@alpine-lab.com
-        github: michaelbaudino
-        name: Michael Baudino
-        twitter: michaelbaudino
-      sylvain:
-        email: s.fertons@gmail.com
-        github: spharian
-        name: Sylvain Fertons
-        twitter: spharian
-      thibault:
-        email: thibault.dalban@alpine-lab.com
-        github: thibaultdalban
-        name: Thibault Dalban
-        twitter: kh_thib
       title: Our team
-      yann:
-        email: yann@vaillant.im
-        github: vayan
-        name: Yann Vaillant
-        twitter: vayan
     what-we-do:
       contracts:
         details: Our <a href="/conditions-generales-de-ventes.pdf" target="_blank">terms</a> (in French) are <a href="https://github.com/tibastral/contrats-francais" target="_blank">agile development contracts</a>. <br>And the code we write <strong>belongs to you</strong>.

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -79,27 +79,7 @@ fr:
       join-us: |-
         Vous voulez vous joindre à nous ? On recherche tout le temps des devs passioné-e-s !<br>
         Ajoutez-vous à l'équipe et faites nous <a href="https://github.com/alpinelab/website">une pull request</a> :-)
-      mike:
-        email: michael.baudino@alpine-lab.com
-        github: michaelbaudino
-        name: Michael Baudino
-        twitter: michaelbaudino
-      sylvain:
-        email: s.fertons@gmail.com
-        github: spharian
-        name: Sylvain Fertons
-        twitter: spharian
-      thibault:
-        email: thibault.dalban@alpine-lab.com
-        github: thibaultdalban
-        name: Thibault Dalban
-        twitter: kh_thib
       title: Notre équipe
-      yann:
-        email: yann@vaillant.im
-        github: vayan
-        name: Yann Vaillant
-        twitter: vayan
     what-we-do:
       contracts:
         details: Nos <a href="/conditions-generales-de-ventes.pdf" target="_blank">CGVs</a> sont des <a href="https://github.com/tibastral/contrats-francais" target="_blank">contrats de développement agile</a>. <br>Et le code que nous écrivons <strong>vous appartient</strong>.


### PR DESCRIPTION
This dead code was removed once with 720522c, but was re-introduced
 with 60f6464.

Maybe we should remove it on LocaleApp related project ?